### PR TITLE
Use HashRouter instead of BrowserRouter for Single page Application

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,24 +2,24 @@ import React from "react";
 import Home from "./pages/Home";
 import Loginpage from "./pages/Loginpage";
 import Signuppage from "./pages/Signuppage";
-import Cartpage from "./pages/CartPage"
+import Cartpage from "./pages/CartPage";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import CheckoutPage from "./pages/CheckoutPage";
 import ProductDetailsPage from "./pages/ProductDetailsPage";
-
+import { HashRouter } from "react-router-dom";
 
 const App = () => {
   return (
-    <BrowserRouter>
+    <HashRouter>
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/signup" element={<Signuppage />} />
         <Route path="/signin" element={<Loginpage />} />
         <Route path="/cart" element={<Cartpage />} />
-        <Route path="/checkout" element={<CheckoutPage/>} />
-        <Route path="/product-details" element={<ProductDetailsPage/>} />
+        <Route path="/checkout" element={<CheckoutPage />} />
+        <Route path="/product-details" element={<ProductDetailsPage />} />
       </Routes>
-    </BrowserRouter>
+    </HashRouter>
   );
 };
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,6 +5,7 @@ import { Provider } from "react-redux";
 import { store } from "./app/store";
 import "./index.css";
 
+
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <Provider store={store}>


### PR DESCRIPTION
#14 
Using HashRouter instead of BrowserRouter. 
HashRouter basically it uses the hash in the URL to render the component for static one-page website